### PR TITLE
correct ports + ssl certificates in makefile + correct quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 name = transcendence
 
+#ssl certificates
+SSL_DIR = nginx/ssl
+KEY = $(SSL_DIR)/key.pem
+CERT = $(SSL_DIR)/cert.pem
+
 COMPOSE_CMD = docker compose 
 
-
-all:
+all:$(CERT)
 	@printf "Launch configuration ${name}...\n"
 	@$(COMPOSE_CMD) up --build
+
+$(CERT):
+	mkdir -p $(SSL_DIR)
+	openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+		-keyout $(KEY) \
+		-out $(CERT) \
+		-subj "/CN=localhost"
 
 down:
 	@printf "Stopping configuration ${name}...\n"
@@ -19,6 +30,8 @@ clean: down
 
 fclean: clean
 	@printf "Total clean of all configurations docker\n"
-	# @docker volume rm 
+	rm -f $(KEY) $(CERT)
+	rm -rf nginx/ssl
+	# @docker volume rm
 
 .PHONY: all down re clean fclean

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -14,23 +14,13 @@ Open `.env` and change:
 - `POSTGRES_PASSWORD` to a secure password
 - `JWT_SECRET` to a random string (at least 32 characters)
 
-### 3. Generate SSL Certificates
-```bash
-mkdir -p nginx/ssl
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-  -keyout nginx/ssl/key.pem \
-  -out nginx/ssl/cert.pem \
-  -subj "/CN=localhost"
-```
-
-### 4. Start Everything
+### 3. Start Everything
 ```bash
 make
 ```
 
-
-### 5. Access the Application
-Open: **https://localhost**
+### 4. Access the Application
+Open: **https://localhost:8443**
 
 ⚠️ Click "Advanced" → "Proceed to localhost" when you see the SSL warning (this is expected with self-signed certificates).
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,8 +15,6 @@ COPY . .
 COPY script/entrypoint.sh /urs/local/bin/
 RUN chmod +x /urs/local/bin/entrypoint.sh
 
-EXPOSE 4000
-
 ENTRYPOINT ["script/entrypoint.sh"]
 
 CMD ["npm", "run", "start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,8 @@ services:
     container_name: nginx
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:80"
+      - "8443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/ssl:/etc/nginx/ssl:ro

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,4 @@ RUN npm ci
 
 COPY . .
 
-EXPOSE 3000
-
 CMD ["npm", "start"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,6 +6,4 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 RUN mkdir -p /etc/nginx/ssl
 
-EXPOSE 80 443
-
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,16 +28,18 @@ http {
   # Http server that redirects to https
   server {
     listen 80;
+	listen [::]:80;
     server_name localhost;
 
     location / {
-      return 301 https://$host$request_uri;
+	  return 301 https://$host:8443$request_uri;
     }
   }
-
-  # httos server
+  # https server
   server {
     listen 443 ssl;
+	listen [::]:443 ssl;
+
     http2 on;
     server_name localhost;
 


### PR DESCRIPTION
Change port because 80 and 443 are protected on school's computers. 
Now it is 8080 and 8443

Remove the EXPOSE from Dockerfile so the ports are only managed in docker-compose.yml (doesnt change a lot but can prevent some mistakes)

Add ssl certificates in the makefile. Delete the certificate with make fclean

Update QUICKSTART.md