### PR TITLE
generate .env and JWT_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,7 @@ POSTGRES_DB=chess_platform
 NODE_ENV=development
 
 # JWT Config
-# temp key
-JWT_SECRET=3iN4H+YfbHdRNugaU2DZWnUTZQea1qt61mVxaWVxj5bWU/29Fc08qxtqGsXeTYu7
-JWT_EXPIRATION=7d
+JWT_SECRET=
 
 # Frontend Config
 REACT_APP_API_URL=https://localhost/api

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ SSL_DIR = nginx/ssl
 KEY = $(SSL_DIR)/key.pem
 CERT = $(SSL_DIR)/cert.pem
 
+# .env file generation
+ENV_FILE = .env
+
 COMPOSE_CMD = docker compose 
 
-all:$(CERT)
+all: $(CERT) $(ENV_FILE)
 	@printf "Launch configuration ${name}...\n"
 	@$(COMPOSE_CMD) up --build
 #	@printf "Server listening on ...https://localhost:4443 and frontend landing page https://localhost:4443/wireframe/landing\n"
@@ -18,6 +21,11 @@ $(CERT):
 		-keyout $(KEY) \
 		-out $(CERT) \
 		-subj "/CN=localhost"
+
+$(ENV_FILE):
+	@cp .env.example .env
+	@JWT=$$(openssl rand -base64 48); sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$$JWT|" .env
+	@printf "Generated new JWT_SECRET in .env\n"
 
 down:
 	@printf "Stopping configuration ${name}...\n"
@@ -34,5 +42,6 @@ fclean: clean
 	@$(COMPOSE_CMD) down --rmi local -v
 	rm -f $(KEY) $(CERT)
 	rm -rf nginx/ssl
+	rm -f .env
 
-.PHONY: all down re clean fclean
+ PHONY: all down re clean fclean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       PORT: 4000
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
-      JWT_EXPIRATION: ${JWT_EXPIRATION}
     volumes:
       - ./backend/src:/app/src
     depends_on:


### PR DESCRIPTION
If .env doesnt exist, copy .env.example and create a 48 character base64 string for JWT.