### PR TITLE
Removed useSocketNotification in Layout

### DIFF
--- a/frontend/src/pages/Header & Footer/Layout.tsx
+++ b/frontend/src/pages/Header & Footer/Layout.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import Navbar from "../../components/Navbar";
-import { useSocketNotification } from "../../notifications";
 import { useDarkMode } from '../../hooks/darkMode'
 
 interface LayoutProps {
@@ -8,7 +7,6 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  useSocketNotification();
   const [isDarkMode, toggleDarkMode] = useDarkMode();
 
   useEffect(() => {


### PR DESCRIPTION
Removed the double call to `useSocketNotification` that causes double calls to notifications.
It was called in two files: `App.tsx` and on `Layout.tsx`. I removed the Layout.tsx one, i doesn't seems to break something and now there's only one notification for each event.