### PR TITLE
 Fixed #169 - User got disconnected after getting rate limited

### DIFF
--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -9,6 +9,12 @@ export async function isLoggedIn(): Promise<{ connected: boolean; username?: str
                 'Authorization': `Bearer ${token}`,
             },
         });
+        //if rate limit
+        if (res.status === 429) {
+            //return error but still consider the user as connected (to avoid infinite loop of logout/login)
+            return { connected: true };
+        }
+
         if (!res.ok) {
             localStorage.removeItem('token');
             return { connected: false };

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,12 +23,12 @@ http {
   gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml+rss;
 
   # rate limit
-  limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+  #limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
 
   # Http server that redirects to https
   server {
     listen 80;
-	listen [::]:80;
+	  listen [::]:80;
     server_name localhost;
 
     location / {
@@ -38,7 +38,7 @@ http {
   # https server
   server {
     listen 443 ssl;
-	listen [::]:443 ssl;
+	  listen [::]:443 ssl;
 
     http2 on;
     server_name localhost;
@@ -73,7 +73,7 @@ http {
 
     # backend api
     location /api/ {
-      limit_req zone=api_limit burst=20 nodelay;
+      #limit_req zone=api_limit burst=20 nodelay;
 
       proxy_pass http://backend:4000/;
       proxy_http_version 1.1;


### PR DESCRIPTION
Removed nginx req_limit because it returns 5xx error that is fail on the subject
Also add a check on ProtectedRoute Wrapper to check if the error code is 429, do not remove token on the local storage
