### PR TITLE
fix: ensure bio field defaults to a space if empty when updating profile

### DIFF
--- a/frontend/src/pages/User/ProfilePage.tsx
+++ b/frontend/src/pages/User/ProfilePage.tsx
@@ -73,7 +73,7 @@ const ProfilePage = () => {
 	    if (field === 'email') body.email = newValue;
 	    if (field === 'firstName') body.firstName = newValue;
 	    if (field === 'lastName') body.lastName = newValue;
-	    if (field === 'bio') body.bio = newValue;
+	    if (field === 'bio') body.bio = newValue ? newValue : ' ';
 
 	    if (Object.keys(body).length === 0) {
 	        return;


### PR DESCRIPTION
we cant change bio if empty, now fixed