### PR TITLE
Feature/moderation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ NODE_ENV=development
 # JWT Config
 JWT_SECRET=
 
+# Admin bootstrap — set to an existing user's email to auto-promote to ADMIN on startup
+ADMIN_EMAIL=
+
 # Frontend Config
 REACT_APP_API_URL=https://localhost/api
 REACT_APP_WS_URL=http://localhost:4000

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,10 +25,11 @@ model User {
   lastName  String?
   bio       String?
 
-  role      UserRole @default(USER)
-  isBanned  Boolean  @default(false)
-  bannedAt  DateTime?
-  banReason String?
+  role        UserRole @default(USER)
+  isBanned    Boolean  @default(false)
+  bannedAt    DateTime?
+  bannedUntil DateTime?
+  banReason   String?
 
   isOnline Boolean  @default(false)
   lastSeen DateTime @default(now())
@@ -44,6 +45,9 @@ model User {
 
   statistics UserStatistics?
   eloHistory EloHistory[]
+
+  reportsFiled    Report[] @relation("ReportsFrom")
+  reportsReceived Report[] @relation("ReportsAgainst")
 
   @@index([email])
   @@index([username])
@@ -184,4 +188,53 @@ enum GameResult {
   STALEMATE
   TIMEOUT
   RESIGNATION
+}
+
+enum AuditAction {
+  BAN
+  TEMP_BAN
+  UNBAN
+  PROMOTE
+  DEMOTE
+  REPORT_RESOLVE
+  REPORT_DISMISS
+}
+
+enum ReportStatus {
+  PENDING
+  RESOLVED
+  DISMISSED
+}
+
+model AuditLog {
+  id         String      @id @default(uuid())
+  adminId    String
+  adminName  String
+  targetId   String?
+  targetName String?
+  action     AuditAction
+  detail     String?
+  createdAt  DateTime    @default(now())
+
+  @@index([adminId])
+  @@index([targetId])
+  @@index([createdAt])
+}
+
+model Report {
+  id           String       @id @default(uuid())
+  reporterId   String
+  reportedId   String
+  reason       String
+  status       ReportStatus @default(PENDING)
+  resolvedById String?
+  resolvedAt   DateTime?
+  createdAt    DateTime     @default(now())
+
+  reporter User @relation("ReportsFrom", fields: [reporterId], references: [id], onDelete: Cascade)
+  reported User @relation("ReportsAgainst", fields: [reportedId], references: [id], onDelete: Cascade)
+
+  @@index([reportedId])
+  @@index([status])
+  @@index([createdAt])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,6 +7,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum UserRole {
+  USER
+  ADMIN
+}
+
 // User model - handles authentication and profiles
 model User {
   id          String  @id @default(uuid())
@@ -19,6 +24,11 @@ model User {
   firstName String?
   lastName  String?
   bio       String?
+
+  role      UserRole @default(USER)
+  isBanned  Boolean  @default(false)
+  bannedAt  DateTime?
+  banReason String?
 
   isOnline Boolean  @default(false)
   lastSeen DateTime @default(now())

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,102 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  UseGuards,
+  NotFoundException,
+  BadRequestException,
+  Req,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AdminGuard } from '../auth/guards/auth.guards';
+import { GameGateway } from '../game/game.gateway';
+
+@Controller('admin')
+@UseGuards(AdminGuard)
+export class AdminController {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly gameGateway: GameGateway,
+  ) {}
+
+  @Get('users')
+  async listUsers() {
+    return this.prisma.user.findMany({
+      select: {
+        id: true,
+        username: true,
+        email: true,
+        role: true,
+        isBanned: true,
+        bannedAt: true,
+        banReason: true,
+        createdAt: true,
+        isOnline: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  @Post('users/:userId/ban')
+  async banUser(
+    @Param('userId') userId: string,
+    @Body() body: { reason?: string },
+    @Req() req: any,
+  ) {
+    const target = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true, isBanned: true },
+    });
+
+    if (!target) throw new NotFoundException('User not found');
+    if (target.role === 'ADMIN') throw new BadRequestException('Cannot ban an admin');
+    if (target.isBanned) throw new BadRequestException('User is already banned');
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { isBanned: true, bannedAt: new Date(), banReason: body.reason ?? null },
+    });
+
+    this.gameGateway.kickUser(userId);
+
+    return { success: true, userId, reason: body.reason };
+  }
+
+  @Post('users/:userId/unban')
+  async unbanUser(@Param('userId') userId: string) {
+    const target = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, isBanned: true },
+    });
+
+    if (!target) throw new NotFoundException('User not found');
+    if (!target.isBanned) throw new BadRequestException('User is not banned');
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { isBanned: false, bannedAt: null, banReason: null },
+    });
+
+    return { success: true, userId };
+  }
+
+  @Post('users/:userId/promote')
+  async promoteUser(@Param('userId') userId: string) {
+    const target = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true },
+    });
+
+    if (!target) throw new NotFoundException('User not found');
+    if (target.role === 'ADMIN') throw new BadRequestException('User is already an admin');
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { role: 'ADMIN' },
+    });
+
+    return { success: true, userId };
+  }
+}

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -21,6 +21,13 @@ export class AdminController {
     private readonly gameGateway: GameGateway,
   ) {}
 
+  private async getAdminName(adminId: string): Promise<string> {
+    const admin = await this.prisma.user.findUnique({ where: { id: adminId }, select: { username: true } });
+    return admin?.username ?? 'Unknown';
+  }
+
+  // ─── Users ────────────────────────────────────────────────────────────────
+
   @Get('users')
   async listUsers() {
     return this.prisma.user.findMany({
@@ -31,6 +38,7 @@ export class AdminController {
         role: true,
         isBanned: true,
         bannedAt: true,
+        bannedUntil: true,
         banReason: true,
         createdAt: true,
         isOnline: true,
@@ -42,33 +50,48 @@ export class AdminController {
   @Post('users/:userId/ban')
   async banUser(
     @Param('userId') userId: string,
-    @Body() body: { reason?: string },
+    @Body() body: { reason?: string; durationHours?: number },
     @Req() req: any,
   ) {
     const target = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, role: true, isBanned: true },
+      select: { id: true, username: true, role: true, isBanned: true },
     });
 
     if (!target) throw new NotFoundException('User not found');
     if (target.role === 'ADMIN') throw new BadRequestException('Cannot ban an admin');
     if (target.isBanned) throw new BadRequestException('User is already banned');
 
+    const bannedUntil = body.durationHours
+      ? new Date(Date.now() + body.durationHours * 3_600_000)
+      : null;
+
     await this.prisma.user.update({
       where: { id: userId },
-      data: { isBanned: true, bannedAt: new Date(), banReason: body.reason ?? null },
+      data: { isBanned: true, bannedAt: new Date(), bannedUntil, banReason: body.reason ?? null },
+    });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: userId,
+        targetName: target.username,
+        action: bannedUntil ? 'TEMP_BAN' : 'BAN',
+        detail: body.reason ?? null,
+      },
     });
 
     this.gameGateway.kickUser(userId);
-
-    return { success: true, userId, reason: body.reason };
+    return { success: true, userId, bannedUntil };
   }
 
   @Post('users/:userId/unban')
-  async unbanUser(@Param('userId') userId: string) {
+  async unbanUser(@Param('userId') userId: string, @Req() req: any) {
     const target = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, isBanned: true },
+      select: { id: true, username: true, isBanned: true },
     });
 
     if (!target) throw new NotFoundException('User not found');
@@ -76,27 +99,148 @@ export class AdminController {
 
     await this.prisma.user.update({
       where: { id: userId },
-      data: { isBanned: false, bannedAt: null, banReason: null },
+      data: { isBanned: false, bannedAt: null, bannedUntil: null, banReason: null },
+    });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: userId,
+        targetName: target.username,
+        action: 'UNBAN',
+      },
     });
 
     return { success: true, userId };
   }
 
   @Post('users/:userId/promote')
-  async promoteUser(@Param('userId') userId: string) {
+  async promoteUser(@Param('userId') userId: string, @Req() req: any) {
     const target = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, role: true },
+      select: { id: true, username: true, role: true },
     });
 
     if (!target) throw new NotFoundException('User not found');
     if (target.role === 'ADMIN') throw new BadRequestException('User is already an admin');
 
-    await this.prisma.user.update({
-      where: { id: userId },
-      data: { role: 'ADMIN' },
+    await this.prisma.user.update({ where: { id: userId }, data: { role: 'ADMIN' } });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: userId,
+        targetName: target.username,
+        action: 'PROMOTE',
+      },
     });
 
     return { success: true, userId };
+  }
+
+  @Post('users/:userId/demote')
+  async demoteUser(@Param('userId') userId: string, @Req() req: any) {
+    if (userId === req.user.userId) throw new BadRequestException('Cannot demote yourself');
+
+    const target = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, username: true, role: true },
+    });
+
+    if (!target) throw new NotFoundException('User not found');
+    if (target.role !== 'ADMIN') throw new BadRequestException('User is not an admin');
+
+    await this.prisma.user.update({ where: { id: userId }, data: { role: 'USER' } });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: userId,
+        targetName: target.username,
+        action: 'DEMOTE',
+      },
+    });
+
+    return { success: true, userId };
+  }
+
+  // ─── Reports ──────────────────────────────────────────────────────────────
+
+  @Get('reports')
+  async listReports() {
+    return this.prisma.report.findMany({
+      include: {
+        reporter: { select: { id: true, username: true } },
+        reported: { select: { id: true, username: true, isBanned: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+    });
+  }
+
+  @Post('reports/:reportId/resolve')
+  async resolveReport(@Param('reportId') reportId: string, @Req() req: any) {
+    const report = await this.prisma.report.findUnique({ where: { id: reportId } });
+    if (!report) throw new NotFoundException('Report not found');
+    if (report.status !== 'PENDING') throw new BadRequestException('Report already actioned');
+
+    await this.prisma.report.update({
+      where: { id: reportId },
+      data: { status: 'RESOLVED', resolvedById: req.user.userId, resolvedAt: new Date() },
+    });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: report.reportedId,
+        action: 'REPORT_RESOLVE',
+        detail: `Report ${reportId}`,
+      },
+    });
+
+    return { success: true };
+  }
+
+  @Post('reports/:reportId/dismiss')
+  async dismissReport(@Param('reportId') reportId: string, @Req() req: any) {
+    const report = await this.prisma.report.findUnique({ where: { id: reportId } });
+    if (!report) throw new NotFoundException('Report not found');
+    if (report.status !== 'PENDING') throw new BadRequestException('Report already actioned');
+
+    await this.prisma.report.update({
+      where: { id: reportId },
+      data: { status: 'DISMISSED', resolvedById: req.user.userId, resolvedAt: new Date() },
+    });
+
+    const adminName = await this.getAdminName(req.user.userId);
+    await this.prisma.auditLog.create({
+      data: {
+        adminId: req.user.userId,
+        adminName,
+        targetId: report.reportedId,
+        action: 'REPORT_DISMISS',
+        detail: `Report ${reportId}`,
+      },
+    });
+
+    return { success: true };
+  }
+
+  // ─── Audit log ────────────────────────────────────────────────────────────
+
+  @Get('audit-logs')
+  async listAuditLogs() {
+    return this.prisma.auditLog.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    });
   }
 }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { GameModule } from '../game/game.module';
+
+@Module({
+  imports: [GameModule],
+  controllers: [AdminController],
+})
+export class AdminModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import { RateLimitGuard } from './auth/guards/rate-limit.guard';
 import { FriendsModule } from './friends/friend.module';
+import { AdminModule } from './admin/admin.module';
  
 @Module({
   imports: [
@@ -27,7 +28,8 @@ import { FriendsModule } from './friends/friend.module';
     GameModule,
     UserModule,
     AuthModule,
-	FriendsModule
+	FriendsModule,
+    AdminModule,
   ],
   providers: [
     {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { UserService } from 'src/user/user.service'
 import { JwtService } from '@nestjs/jwt'
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
+import { isUsernameAllowed } from '../common/username-filter';
 
 type AuthInput = { username: string; password: string };
 type SignInData = { userId: string; username: string; fingerprint: string };
@@ -24,6 +25,10 @@ export class AuthService {
   }): Promise<AuthResult> {
     if (!data.email || !data.username || !data.password) {
       throw new BadRequestException('Email, username, and password are mandatory');
+    }
+
+    if (!isUsernameAllowed(data.username)) {
+      throw new BadRequestException('Username contains prohibited content');
     }
 
     const existingUser = await this.prisma.user.findFirst({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -82,7 +82,16 @@ export class AuthService {
 
     if (!user) return null;
 
-    if (user.isBanned) throw new UnauthorizedException('Your account has been banned');
+    if (user.isBanned) {
+      if (user.bannedUntil && user.bannedUntil <= new Date()) {
+        await this.prisma.user.update({
+          where: { id: user.id },
+          data: { isBanned: false, bannedUntil: null, banReason: null },
+        });
+      } else {
+        throw new UnauthorizedException('Your account has been banned');
+      }
+    }
 
     const valid = await bcrypt.compare(input.password, user.password);
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -82,6 +82,8 @@ export class AuthService {
 
     if (!user) return null;
 
+    if (user.isBanned) throw new UnauthorizedException('Your account has been banned');
+
     const valid = await bcrypt.compare(input.password, user.password);
 
     if (!valid) return null;

--- a/backend/src/auth/guards/auth.guards.ts
+++ b/backend/src/auth/guards/auth.guards.ts
@@ -10,6 +10,22 @@ import { Socket } from 'socket.io';
 import { JWT_SECRET } from '../configs/jwtsecret';
 import { PrismaService } from '../../prisma/prisma.service';
 
+async function checkBan(prisma: PrismaService, userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isBanned: true, bannedUntil: true },
+  });
+  if (!user?.isBanned) return;
+  if (user.bannedUntil && user.bannedUntil <= new Date()) {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { isBanned: false, bannedUntil: null, banReason: null, bannedAt: null },
+    });
+    return;
+  }
+  throw new UnauthorizedException('Your account has been banned');
+}
+
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(private jwtService: JwtService, private prisma: PrismaService) {}
@@ -24,11 +40,7 @@ export class AuthGuard implements CanActivate {
 
     try {
       const tokenPayload = await this.jwtService.verifyAsync(token);
-      const user = await this.prisma.user.findUnique({
-        where: { id: tokenPayload.sub },
-        select: { isBanned: true },
-      });
-      if (user?.isBanned) throw new UnauthorizedException('Your account has been banned');
+      await checkBan(this.prisma, tokenPayload.sub);
       request.user = { userId: tokenPayload.sub, username: tokenPayload.username };
       return true;
     } catch (error) {
@@ -51,9 +63,19 @@ export class AdminGuard implements CanActivate {
       const tokenPayload = await this.jwtService.verifyAsync(token);
       const user = await this.prisma.user.findUnique({
         where: { id: tokenPayload.sub },
-        select: { role: true, isBanned: true },
+        select: { role: true, isBanned: true, bannedUntil: true },
       });
-      if (!user || user.isBanned) throw new UnauthorizedException('Account unavailable');
+      if (!user) throw new UnauthorizedException('Account unavailable');
+      if (user.isBanned) {
+        if (user.bannedUntil && user.bannedUntil <= new Date()) {
+          await this.prisma.user.update({
+            where: { id: tokenPayload.sub },
+            data: { isBanned: false, bannedUntil: null, banReason: null, bannedAt: null },
+          });
+        } else {
+          throw new UnauthorizedException('Your account has been banned');
+        }
+      }
       if (user.role !== 'ADMIN') throw new ForbiddenException('Admin access required');
       request.user = { userId: tokenPayload.sub, username: tokenPayload.username };
       return true;
@@ -75,11 +97,7 @@ export class WsAuthGuard implements CanActivate {
 
     try {
       const payload = await this.jwtService.verifyAsync(token, { secret: JWT_SECRET });
-      const user = await this.prisma.user.findUnique({
-        where: { id: payload.sub },
-        select: { isBanned: true },
-      });
-      if (user?.isBanned) throw new UnauthorizedException('Your account has been banned');
+      await checkBan(this.prisma, payload.sub);
       client.data.userId = payload.sub;
       client.data.username = payload.username;
       return true;

--- a/backend/src/auth/guards/auth.guards.ts
+++ b/backend/src/auth/guards/auth.guards.ts
@@ -1,55 +1,91 @@
-import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common'
-import { JwtService } from '@nestjs/jwt'
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Socket } from 'socket.io';
 import { JWT_SECRET } from '../configs/jwtsecret';
+import { PrismaService } from '../../prisma/prisma.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-	constructor(private jwtService: JwtService) { }
-	async canActivate(context: ExecutionContext) {
-		const request = context.switchToHttp().getRequest();
-		const authorization = request.headers.authorization;
-		if (!authorization) {
-			throw new UnauthorizedException('No authorization header');
-		}
-		const token = authorization?.split(' ')[1];
-		if (!token) {
-			throw new UnauthorizedException('No token provided');
-		}
-		try {
-			const tokenPayload = await this.jwtService.verifyAsync(token);
-			request.user = {
-				userId: tokenPayload.sub,
-				username: tokenPayload.username
-			}
-			return true;
-		}
-		catch (error) {
-			throw new UnauthorizedException('Invalid Token');
-		}
-	}
+  constructor(private jwtService: JwtService, private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const authorization = request.headers.authorization;
+    if (!authorization) throw new UnauthorizedException('No authorization header');
+
+    const token = authorization?.split(' ')[1];
+    if (!token) throw new UnauthorizedException('No token provided');
+
+    try {
+      const tokenPayload = await this.jwtService.verifyAsync(token);
+      const user = await this.prisma.user.findUnique({
+        where: { id: tokenPayload.sub },
+        select: { isBanned: true },
+      });
+      if (user?.isBanned) throw new UnauthorizedException('Your account has been banned');
+      request.user = { userId: tokenPayload.sub, username: tokenPayload.username };
+      return true;
+    } catch (error) {
+      if (error instanceof UnauthorizedException) throw error;
+      throw new UnauthorizedException('Invalid Token');
+    }
+  }
 }
 
-//to access the game
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private jwtService: JwtService, private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const token = request.headers.authorization?.split(' ')[1];
+    if (!token) throw new UnauthorizedException('No token provided');
+
+    try {
+      const tokenPayload = await this.jwtService.verifyAsync(token);
+      const user = await this.prisma.user.findUnique({
+        where: { id: tokenPayload.sub },
+        select: { role: true, isBanned: true },
+      });
+      if (!user || user.isBanned) throw new UnauthorizedException('Account unavailable');
+      if (user.role !== 'ADMIN') throw new ForbiddenException('Admin access required');
+      request.user = { userId: tokenPayload.sub, username: tokenPayload.username };
+      return true;
+    } catch (error) {
+      if (error instanceof UnauthorizedException || error instanceof ForbiddenException) throw error;
+      throw new UnauthorizedException('Invalid Token');
+    }
+  }
+}
+
 @Injectable()
 export class WsAuthGuard implements CanActivate {
-	constructor(private jwtService: JwtService) { }
+  constructor(private jwtService: JwtService, private prisma: PrismaService) {}
 
-	async canActivate(context: ExecutionContext): Promise<boolean> {
-		const client: Socket = context.switchToWs().getClient();
-		const token = client.handshake.auth?.token;
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const client: Socket = context.switchToWs().getClient();
+    const token = client.handshake.auth?.token;
+    if (!token) throw new UnauthorizedException('No authentication token');
 
-		if (!token) {
-			throw new UnauthorizedException('No authentication token');
-		}
-
-		try {
-			const payload = await this.jwtService.verifyAsync(token, { secret: JWT_SECRET });
-			client.data.userId = payload.sub;
-			client.data.uername = payload.username;
-			return (true);
-		} catch {
-			throw new UnauthorizedException('Invalid token');
-		}
-	}
+    try {
+      const payload = await this.jwtService.verifyAsync(token, { secret: JWT_SECRET });
+      const user = await this.prisma.user.findUnique({
+        where: { id: payload.sub },
+        select: { isBanned: true },
+      });
+      if (user?.isBanned) throw new UnauthorizedException('Your account has been banned');
+      client.data.userId = payload.sub;
+      client.data.username = payload.username;
+      return true;
+    } catch (error) {
+      if (error instanceof UnauthorizedException) throw error;
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
 }

--- a/backend/src/common/username-filter.ts
+++ b/backend/src/common/username-filter.ts
@@ -1,0 +1,20 @@
+const BLOCKED_TERMS = [
+  // strong profanity
+  'fuck', 'shit', 'cunt', 'cock', 'pussy', 'bastard', 'asshole', 'arsehole',
+  'motherfuck', 'bullshit', 'dickhead', 'jackass', 'prick', 'twat', 'wanker',
+  'bitch', 'whore', 'slut',
+  // slurs — racial/ethnic
+  'nigger', 'nigga', 'kike', 'spic', 'chink', 'gook', 'wetback', 'coon',
+  'cracker', 'honky', 'beaner', 'raghead', 'sandnigger', 'zipperhead',
+  // slurs — sexuality/gender
+  'faggot', 'fag', 'dyke', 'tranny', 'shemale',
+  // hate groups / figures
+  'hitler', 'nazi', 'kkk', 'neonazi',
+  // common leet-speak bypasses
+  'fvck', 'fuk', 'phuck', 'sh1t', 'b1tch', 'n1gger', 'nigg3r',
+];
+
+export function isUsernameAllowed(username: string): boolean {
+  const normalized = username.toLowerCase().replace(/[_.\-]/g, '');
+  return !BLOCKED_TERMS.some(term => normalized.includes(term));
+}

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -121,9 +121,27 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
     try {
       const payload = await this.jwtService.verifyAsync(token, { secret: JWT_SECRET });
+      const user = await this.prisma.user.findUnique({
+        where: { id: payload.sub },
+        select: { isBanned: true },
+      });
+      if (user?.isBanned) {
+        client.emit('banned', { message: 'Your account has been banned.' });
+        client.disconnect(true);
+        return;
+      }
       client.data.userId = payload.sub;
     } catch {
       client.disconnect();
+    }
+  }
+
+  kickUser(userId: string): void {
+    for (const [, socket] of this.server.sockets.sockets) {
+      if (socket.data.userId === userId) {
+        socket.emit('banned', { message: 'Your account has been banned.' });
+        socket.disconnect(true);
+      }
     }
   }
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { join } from 'path';
+import { PrismaService } from './prisma/prisma.service';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -33,6 +34,15 @@ async function bootstrap() {
 
     credentials: true,
   });
+
+  const adminEmail = process.env.ADMIN_EMAIL;
+  if (adminEmail) {
+    const prisma = app.get(PrismaService);
+    await prisma.user.updateMany({
+      where: { email: adminEmail },
+      data: { role: 'ADMIN' },
+    }).catch(() => {});
+  }
 
   await app.listen(4000, '0.0.0.0');
   console.log('Backend is running on http://localhost:4000');

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
     Controller,
     Patch,
+    Post,
     Get,
     Body,
     Param,
@@ -201,5 +202,17 @@ export class UserController {
         const user = await this.userService.findById(id);
         if (!user) throw new NotFoundException('User not found');
         return user;
+    }
+
+    @UseGuards(AuthGuard)
+    @Post(':userId/report')
+    async reportUser(
+        @Param('userId') userId: string,
+        @Body() body: { reason: string },
+        @Req() req: any,
+    ) {
+        if (!body.reason?.trim()) throw new BadRequestException('Reason is required');
+        await this.userService.createReport(req.user.userId, userId, body.reason.trim());
+        return { success: true };
     }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -22,12 +22,13 @@ type UserProfile = {
     role?: string;
 };
 
-type UserAuth = { id: string; username: string; password: string; fingerprint: string; isBanned: boolean };
+type UserAuth = { id: string; username: string; password: string; fingerprint: string; isBanned: boolean; bannedUntil: Date | null };
 type newFingerPrint = { id: string; fingerprint: string };
 type UserHistoryItem = {
     id: string;
     date: string;
     opponent: string;
+    opponentId: string | null;
     result: 'Win' | 'Loss' | 'Draw';
     moves: number;
     mode: 'Bullet' | 'Blitz' | 'Rapid';
@@ -102,7 +103,7 @@ export class UserService {
     async findAuthUser(username: string): Promise<UserAuth | null> {
         return this.prisma.user.findUnique({
             where: { username },
-            select: { id: true, username: true, password: true, fingerprint: true, isBanned: true },
+            select: { id: true, username: true, password: true, fingerprint: true, isBanned: true, bannedUntil: true },
         });
     }
 
@@ -489,12 +490,8 @@ export class UserService {
             const isWhite = game.whitePlayerId === id;
             const isBlack = game.blackPlayerId === id;
 
-            const opponent =
-                isWhite
-                    ? game.blackPlayer?.username
-                    : isBlack
-                        ? game.whitePlayer?.username
-                        : 'Unknown';
+            const opponentPlayer = isWhite ? game.blackPlayer : isBlack ? game.whitePlayer : null;
+            const opponent = opponentPlayer?.username;
 
             const refDate = game.endedAt || game.createdAt;
             const dateStr = refDate.toISOString().slice(0, 10);
@@ -532,7 +529,8 @@ export class UserService {
             const item: UserHistoryItem = {
                 id: game.id,
                 date: dateStr,
-                opponent: opponent ?? 'Unknowns',
+                opponent: opponent ?? 'Unknown',
+                opponentId: opponentPlayer?.id ?? null,
                 result,
                 moves,
                 mode,
@@ -543,5 +541,20 @@ export class UserService {
         });
 
         return history;
+    }
+
+    async createReport(reporterId: string, reportedId: string, reason: string): Promise<void> {
+        if (reporterId === reportedId) {
+            throw new BadRequestException('Cannot report yourself');
+        }
+        const target = await this.prisma.user.findUnique({ where: { id: reportedId } });
+        if (!target) throw new NotFoundException('User not found');
+
+        const existing = await this.prisma.report.findFirst({
+            where: { reporterId, reportedId, status: 'PENDING' },
+        });
+        if (existing) throw new BadRequestException('You already have a pending report for this user');
+
+        await this.prisma.report.create({ data: { reporterId, reportedId, reason } });
     }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -19,6 +19,7 @@ type UserProfile = {
     bio: string | null;
     avatarUrl: string | null;
     email?: string | null;
+    role?: string;
 };
 
 type UserAuth = { id: string; username: string; password: string; fingerprint: string; isBanned: boolean };
@@ -130,6 +131,7 @@ export class UserService {
                 lastName: true,
                 bio: true,
                 avatarUrl: true,
+                role: true,
             },
         });
     }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -21,7 +21,7 @@ type UserProfile = {
     email?: string | null;
 };
 
-type UserAuth = { id: string; username: string; password: string, fingerprint: string };
+type UserAuth = { id: string; username: string; password: string; fingerprint: string; isBanned: boolean };
 type newFingerPrint = { id: string; fingerprint: string };
 type UserHistoryItem = {
     id: string;
@@ -101,7 +101,7 @@ export class UserService {
     async findAuthUser(username: string): Promise<UserAuth | null> {
         return this.prisma.user.findUnique({
             where: { username },
-            select: { id: true, username: true, password: true, fingerprint: true, },
+            select: { id: true, username: true, password: true, fingerprint: true, isBanned: true },
         });
     }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
+import { isUsernameAllowed } from '../common/username-filter';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import * as bcrypt from 'bcrypt';
@@ -175,6 +176,9 @@ export class UserService {
       }
 
         if (newUsername !== undefined && newUsername !== null && newUsername !== '') {
+            if (!isUsernameAllowed(newUsername)) {
+                throw new BadRequestException('Username contains prohibited content');
+            }
             data.username = newUsername;
         }
         if (newEmail !== undefined && newEmail !== null && newEmail !== '') {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,8 +19,10 @@ import SoloLauncher from './pages/Game/SoloLauncher';
 import SoloGamePage from './pages/Game/SoloGamePage';
 //Import loaders from services
 import { ProtectedLayout } from './components/ProtectedRoute';
-import { dashboardLoader, userLoader, friendLoader } from './services/loaders.service';
+import { AdminRoute } from './components/AdminRoute';
+import { dashboardLoader, userLoader, friendLoader, adminLoader } from './services/loaders.service';
 import { ErrorPage } from './pages/Error/ErrorPage';
+import AdminPanel from './pages/Admin/AdminPanel';
 
 function NotificationListener({ children }: { children: React.ReactNode }) {
   useSocketNotification();
@@ -77,6 +79,12 @@ const router = createBrowserRouter([
           { path: "/solo-game", element: <SoloGamePage /> },
           { path: "*", element: <NotFound /> },
         ],
+       },
+       {
+         element: <AdminRoute />,
+         children: [
+           { path: "/admin", element: <AdminPanel />, loader: adminLoader, errorElement: <ErrorPage /> },
+         ],
        }
 
     ]

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { useNotification } from '../notifications';
+
+export function AdminRoute() {
+    const navigate = useNavigate();
+    const { push } = useNotification();
+    const checked = useRef(false);
+
+    useEffect(() => {
+        if (checked.current) return;
+        checked.current = true;
+
+        const token = localStorage.getItem('token');
+        if (!token) {
+            push({ type: 'error', title: 'Access denied', message: 'Admin access required.', duration: 5000 });
+            navigate('/');
+            return;
+        }
+
+        fetch('/api/users/me', { headers: { Authorization: `Bearer ${token}` } })
+            .then(r => r.ok ? r.json() : null)
+            .then(data => {
+                if (!data || data.role !== 'ADMIN') {
+                    push({ type: 'error', title: 'Access denied', message: 'Admin access required.', duration: 5000 });
+                    navigate('/dashboard');
+                }
+            })
+            .catch(() => navigate('/'));
+    }, []);
+
+    return <Outlet />;
+}

--- a/frontend/src/components/GameHistoryList.tsx
+++ b/frontend/src/components/GameHistoryList.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as Icons from 'lucide-react';
 
 export interface GameHistoryItem {
   id: string;
   date: string;
   opponent: string;
+  opponentId?: string | null;
   result: 'Win' | 'Loss' | 'Draw';
   moves: number;
   mode: 'Bullet' | 'Blitz' | 'Rapid';
@@ -12,6 +13,74 @@ export interface GameHistoryItem {
 }
 interface GameHistoryListProps {
   history: GameHistoryItem[];
+}
+
+function ReportButton({ opponentId, opponentName }: { opponentId: string; opponentName: string }) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function submit() {
+    if (!reason.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/users/${opponentId}/report`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+        body: JSON.stringify({ reason: reason.trim() }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? 'Failed');
+      }
+      setSent(true);
+      setTimeout(() => { setOpen(false); setSent(false); setReason(''); }, 1500);
+    } catch {
+      // silent — user sees nothing, report failed
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)}
+        className="text-text-default/30 hover:text-red-400 transition-colors p-1 rounded"
+        title="Report player">
+        <Icons.Flag size={14} />
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setOpen(false)}>
+          <div className="bg-primary rounded-xl shadow-xl p-5 w-full max-w-sm mx-4 flex flex-col gap-3" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between">
+              <h3 className="font-heading font-bold text-text-default flex items-center gap-2">
+                <Icons.Flag size={16} className="text-accent" /> Report {opponentName}
+              </h3>
+              <button onClick={() => setOpen(false)} className="text-text-default/40 hover:text-text-default"><Icons.X size={18} /></button>
+            </div>
+            {sent ? (
+              <p className="text-green-400 text-sm text-center py-2">Report submitted ✓</p>
+            ) : (
+              <>
+                <textarea value={reason} onChange={e => setReason(e.target.value)}
+                  placeholder="e.g. Using a chess engine, abusive chat…"
+                  rows={3}
+                  className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60 resize-none" />
+                <div className="flex gap-2 justify-end">
+                  <button onClick={() => setOpen(false)} className="px-4 py-2 rounded-lg text-sm font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all">Cancel</button>
+                  <button onClick={submit} disabled={!reason.trim() || loading}
+                    className="px-4 py-2 rounded-lg text-sm font-semibold bg-tertiary hover:bg-tertiary-hover text-text-default transition-all disabled:opacity-40">
+                    {loading ? '…' : 'Report'}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
 }
 
 export default function GameHistoryList({ history }: GameHistoryListProps) {
@@ -60,8 +129,9 @@ export default function GameHistoryList({ history }: GameHistoryListProps) {
               
               {/* --- MOBILE VIEW (Visible only on small screens) --- */}
               <div className="flex justify-between items-center w-full md:hidden mb-1">
-                 <span className="font-bold text-text-default text-base truncate pr-2">
+                 <span className="font-bold text-text-default text-base truncate pr-2 flex items-center gap-2">
                    {game.opponent}
+                   {game.opponentId && <ReportButton opponentId={game.opponentId} opponentName={game.opponent} />}
                  </span>
                  <span className={`px-3 py-1 rounded-full text-xs font-bold w-16 text-center shrink-0 ${getResultColor(game.result)}`}>
                     {game.result}
@@ -85,8 +155,9 @@ export default function GameHistoryList({ history }: GameHistoryListProps) {
               </div>
 
               {/* Opponent */}
-              <div className="hidden md:flex col-span-4 text-left truncate">
+              <div className="hidden md:flex col-span-4 text-left items-center gap-2 truncate">
                 <span className="font-bold text-text-default text-sm truncate">{game.opponent}</span>
+                {game.opponentId && <ReportButton opponentId={game.opponentId} opponentName={game.opponent} />}
               </div>
 
               {/* Result */}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Toggle from './Toggle';
-import { Menu, X, LogIn, LogOut } from 'lucide-react';
+import { Menu, X, LogIn, LogOut, ShieldAlert } from 'lucide-react';
 import LoginPopUp from './LoginPopUp';
 import { socketService } from '../services/socket.service';
 
@@ -13,6 +13,7 @@ interface NavbarProps {
 export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [modalView, setModalView] = useState<'login' | 'register'>('login');
@@ -25,14 +26,21 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
     setIsAuthenticated(!!token);
     if (token) {
       socketService.connect();
+      fetch('/api/users/me', { headers: { Authorization: `Bearer ${token}` } })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => setIsAdmin(data?.role === 'ADMIN'))
+        .catch(() => setIsAdmin(false));
+    } else {
+      setIsAdmin(false);
     }
   }, [location]);
 
   const handleLogout = () => {
     localStorage.removeItem('token');
     setIsAuthenticated(false);
+    setIsAdmin(false);
     socketService.disconnect();
-		window.dispatchEvent(new Event('auth-change'));
+    window.dispatchEvent(new Event('auth-change'));
     navigate('/');
     setIsMenuOpen(false);
   };
@@ -40,27 +48,37 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
   const openModal = (view: 'login' | 'register') => {
     setModalView(view);
     setIsAuthModalOpen(true);
-    setIsMenuOpen(false); // Close mobile menu if open
+    setIsMenuOpen(false);
   };
 
   const handleLoginSuccess = () => {
     setIsAuthenticated(true);
     setIsAuthModalOpen(false);
-		window.dispatchEvent(new Event('auth-change'));
+    window.dispatchEvent(new Event('auth-change'));
   };
 
   return (
     <nav className="relative bg-primary text-text-default shadow-md transition-colors duration-200">
       <div className="flex items-center justify-between px-6 py-4">
-        {/* LOGO (name) */}
+        {/* LOGO */}
         <Link to="/" className="text-2xl font-heading font-bold">42 Chess</Link>
 
         {/* DESKTOP NAVIGATION */}
         <div className="hidden md:flex items-center gap-8 font-body font-medium">
-          <div className="flex gap-6">
+          <div className="flex gap-6 items-center">
             <Link to="/" className="hover:text-accent transition-colors">Home</Link>
             <Link to="/dashboard" className="hover:text-accent transition-colors">Dashboard</Link>
             <Link to="/user" className="hover:text-accent transition-colors">Profile</Link>
+            {isAdmin && (
+              <Link
+                to="/admin"
+                className="flex items-center gap-1.5 text-accent hover:text-accent/70 transition-colors font-semibold"
+                title="Admin panel"
+              >
+                <ShieldAlert size={16} />
+                Admin
+              </Link>
+            )}
           </div>
 
           <div className="flex items-center gap-6">
@@ -71,8 +89,6 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
               onLabel="🌙"
               offLabel="☀️"
             />
-
-            {/* Dynamic Login / Logout Icon */}
             {isAuthenticated ? (
               <button onClick={handleLogout} className="hover:text-red-400 transition-colors" title="Logout">
                 <LogOut size={20} />
@@ -97,6 +113,16 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
           <Link to="/" className="hover:text-accent transition-colors" onClick={() => setIsMenuOpen(false)}>Home</Link>
           <Link to="/dashboard" className="hover:text-accent transition-colors" onClick={() => setIsMenuOpen(false)}>Dashboard</Link>
           <Link to="/user" className="hover:text-accent transition-colors" onClick={() => setIsMenuOpen(false)}>Profile</Link>
+          {isAdmin && (
+            <Link
+              to="/admin"
+              className="flex items-center gap-1.5 text-accent font-semibold hover:text-accent/70 transition-colors"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              <ShieldAlert size={16} />
+              Admin Panel
+            </Link>
+          )}
 
           <div className="flex items-center justify-between pt-4 border-t border-gray-300/20">
             <span>Dark Mode</span>
@@ -109,7 +135,6 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
             />
           </div>
 
-          {/* Mobile Login / Logout Button */}
           {isAuthenticated ? (
             <button
               onClick={handleLogout}
@@ -130,7 +155,6 @@ export default function Navbar({ isDarkMode, toggleDarkMode }: NavbarProps) {
         </div>
       )}
 
-      {/* The PopUp Component mapped to the states */}
       <LoginPopUp
         isOpen={isAuthModalOpen}
         onClose={() => setIsAuthModalOpen(false)}

--- a/frontend/src/components/chessgui/ChessGame.tsx
+++ b/frontend/src/components/chessgui/ChessGame.tsx
@@ -220,7 +220,7 @@ const ChessGame: React.FC<ChessGameProps> = (props) => {
 			</div>
 
 			{promotionMove && <PromotionPopup color={playerColor} theme={classicTheme} onSelect={completePromotion} />}
-			{showPopup && <GameEndPopup status={gameStatus} onHome={() => navigate('/')} onNewGame={() => navigate(destination)} onClose={() => setShowPopup(false)} />}
+			{showPopup && <GameEndPopup status={gameStatus} onHome={() => navigate('/')} onNewGame={() => navigate(destination)} onClose={() => setShowPopup(false)} opponentUserId={props.opponentUserId} opponentUsername={props.opponentUsername} />}
 		</div>
 	);
 };

--- a/frontend/src/components/chessgui/GameEndPopup.tsx
+++ b/frontend/src/components/chessgui/GameEndPopup.tsx
@@ -1,48 +1,97 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Button from '../Button';
-import { X } from 'lucide-react';
+import { X, Flag } from 'lucide-react';
 
 interface GameEndPopupProps {
 	status: string;
 	onHome: () => void;
 	onNewGame: () => void;
 	onClose: () => void;
+	opponentUserId?: string | null;
+	opponentUsername?: string | null;
 }
 
-const GameEndPopup: React.FC<GameEndPopupProps> = ({ status, onHome, onNewGame, onClose }) => {
+const GameEndPopup: React.FC<GameEndPopupProps> = ({
+	status, onHome, onNewGame, onClose, opponentUserId, opponentUsername,
+}) => {
+	const [reportOpen, setReportOpen] = useState(false);
+	const [reason, setReason] = useState('');
+	const [loading, setLoading] = useState(false);
+	const [sent, setSent] = useState(false);
+
+	async function submitReport() {
+		if (!reason.trim() || !opponentUserId) return;
+		setLoading(true);
+		try {
+			const res = await fetch(`/api/users/${opponentUserId}/report`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${localStorage.getItem('token')}`,
+				},
+				body: JSON.stringify({ reason: reason.trim() }),
+			});
+			if (res.ok) {
+				setSent(true);
+				setTimeout(() => { setReportOpen(false); setSent(false); setReason(''); }, 1500);
+			}
+		} finally {
+			setLoading(false);
+		}
+	}
+
 	return (
 		<div className="fixed inset-0 bg-background-light/80 backdrop-blur-sm z-50 flex items-center justify-center font-body">
-			{/* Reusing the styling from your GamePage waiting screen */}
 			<div className="relative bg-primary rounded-2xl shadow-xl border p-10 text-center flex flex-col items-center gap-6 max-w-sm w-full mx-4">
-				
-				{/* Close Button */}
-				<button 
-					onClick={onClose}
+
+				<button onClick={onClose}
 					className="absolute top-4 right-4 p-1 rounded-full text-text-default hover:text-accent transition-colors"
-					aria-label="Close popup"
-				>
-					<X size={24} /> 
+					aria-label="Close popup">
+					<X size={24} />
 				</button>
 
 				<div className="flex flex-col gap-2">
-					<h2 className="text-3xl font-heading font-bold text-text-default">
-						Game Over
-					</h2>
-					<p className="text-lg font-medium text-text-default">
-						{status}
-					</p>
+					<h2 className="text-3xl font-heading font-bold text-text-default">Game Over</h2>
+					<p className="text-lg font-medium text-text-default">{status}</p>
 				</div>
 
 				<div className="flex w-full gap-3 mt-4 text-text-default">
-					{/* Reusing your custom Button component */}
-					<Button variant="secondary" onClick={onHome} className="flex-1">
-						Home
-					</Button>
-					<Button variant="secondary" onClick={onNewGame} className="flex-1">
-						New Game
-					</Button>
+					<Button variant="secondary" onClick={onHome} className="flex-1">Home</Button>
+					<Button variant="secondary" onClick={onNewGame} className="flex-1">New Game</Button>
 				</div>
 
+				{opponentUserId && !reportOpen && (
+					<button onClick={() => setReportOpen(true)}
+						className="flex items-center gap-1.5 text-xs text-text-default/30 hover:text-red-400 transition-colors mt-1">
+						<Flag size={13} /> Report {opponentUsername ?? 'opponent'}
+					</button>
+				)}
+
+				{reportOpen && (
+					<div className="w-full flex flex-col gap-3 border-t border-accent/10 pt-4">
+						<p className="text-sm text-text-default/60 text-left">Why are you reporting {opponentUsername}?</p>
+						{sent ? (
+							<p className="text-green-400 text-sm text-center py-1">Report submitted ✓</p>
+						) : (
+							<>
+								<textarea value={reason} onChange={e => setReason(e.target.value)}
+									placeholder="e.g. Using a chess engine…"
+									rows={3}
+									className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60 resize-none text-left" />
+								<div className="flex gap-2 justify-end">
+									<button onClick={() => setReportOpen(false)}
+										className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all">
+										Cancel
+									</button>
+									<button onClick={submitReport} disabled={!reason.trim() || loading}
+										className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-tertiary hover:bg-tertiary-hover text-text-default transition-all disabled:opacity-40">
+										{loading ? '…' : 'Submit'}
+									</button>
+								</div>
+							</>
+						)}
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/components/chessgui/types.ts
+++ b/frontend/src/components/chessgui/types.ts
@@ -40,4 +40,6 @@ export interface ChessGameProps {
   initialGameOver?: { winner: string; result: string } | null;
   incrementMs?: number;
   players?: { white: string; black: string } | null;
+  opponentUserId?: string | null;
+  opponentUsername?: string | null;
 }

--- a/frontend/src/pages/Admin/AdminPanel.tsx
+++ b/frontend/src/pages/Admin/AdminPanel.tsx
@@ -12,32 +12,48 @@ interface AdminUser {
     role: 'USER' | 'ADMIN';
     isBanned: boolean;
     bannedAt: string | null;
+    bannedUntil: string | null;
     banReason: string | null;
     createdAt: string;
     isOnline: boolean;
 }
 
+interface Report {
+    id: string;
+    reason: string;
+    status: 'PENDING' | 'RESOLVED' | 'DISMISSED';
+    createdAt: string;
+    reporter: { id: string; username: string };
+    reported: { id: string; username: string; isBanned: boolean };
+}
+
+interface AuditLog {
+    id: string;
+    adminId: string;
+    adminName: string;
+    targetId: string | null;
+    targetName: string | null;
+    action: string;
+    detail: string | null;
+    createdAt: string;
+}
+
 interface LoaderData {
     me: { id: string; username: string; role: string };
     users: AdminUser[];
+    reports: Report[];
+    auditLogs: AuditLog[];
 }
 
+// ─── Shared components ────────────────────────────────────────────────────────
+
 function ConfirmDialog({
-    title,
-    message,
-    confirmLabel,
-    confirmVariant = 'tertiary',
-    onConfirm,
-    onCancel,
-    children,
+    title, message, confirmLabel, confirmVariant = 'tertiary',
+    onConfirm, onCancel, children,
 }: {
-    title: string;
-    message: string;
-    confirmLabel: string;
+    title: string; message: string; confirmLabel: string;
     confirmVariant?: 'primary' | 'secondary' | 'accent' | 'tertiary';
-    onConfirm: () => void;
-    onCancel: () => void;
-    children?: React.ReactNode;
+    onConfirm: () => void; onCancel: () => void; children?: React.ReactNode;
 }) {
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
@@ -46,21 +62,17 @@ function ConfirmDialog({
                 <p className="text-sm text-text-default/80">{message}</p>
                 {children}
                 <div className="flex gap-3 justify-end mt-2">
-                    <Button variant="secondary" onClick={onCancel} className="px-4 py-2 text-sm">
-                        Cancel
-                    </Button>
-                    <Button variant={confirmVariant} onClick={onConfirm} className="px-4 py-2 text-sm">
-                        {confirmLabel}
-                    </Button>
+                    <Button variant="secondary" onClick={onCancel} className="px-4 py-2 text-sm">Cancel</Button>
+                    <Button variant={confirmVariant} onClick={onConfirm} className="px-4 py-2 text-sm">{confirmLabel}</Button>
                 </div>
             </Card>
         </div>
     );
 }
 
-function StatusBadge({ user }: { user: AdminUser }) {
+function UserStatusBadge({ user }: { user: AdminUser }) {
     if (user.isBanned)
-        return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-red-900/60 text-red-300"><Icons.Ban size={11} /> Banned</span>;
+        return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-red-900/60 text-red-300"><Icons.Ban size={11} /> {user.bannedUntil ? 'Temp ban' : 'Banned'}</span>;
     if (user.role === 'ADMIN')
         return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-accent/20 text-accent"><Icons.ShieldCheck size={11} /> Admin</span>;
     if (user.isOnline)
@@ -68,147 +80,86 @@ function StatusBadge({ user }: { user: AdminUser }) {
     return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-primary/40 text-text-default/50"><Icons.Circle size={11} /> Offline</span>;
 }
 
-export default function AdminPanel() {
-    const { me, users: initialUsers } = useLoaderData() as LoaderData;
-    const { revalidate } = useRevalidator();
-    const { push } = useNotification();
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+    BAN:            { label: 'Banned',        color: 'text-red-400' },
+    TEMP_BAN:       { label: 'Temp banned',   color: 'text-orange-400' },
+    UNBAN:          { label: 'Unbanned',       color: 'text-green-400' },
+    PROMOTE:        { label: 'Promoted',       color: 'text-accent' },
+    DEMOTE:         { label: 'Demoted',        color: 'text-yellow-400' },
+    REPORT_RESOLVE: { label: 'Report resolved', color: 'text-blue-400' },
+    REPORT_DISMISS: { label: 'Report dismissed', color: 'text-text-default/40' },
+};
 
+// ─── Tabs ─────────────────────────────────────────────────────────────────────
+
+function UsersTab({ users, me, apiFetch }: {
+    users: AdminUser[];
+    me: { id: string; username: string };
+    apiFetch: (url: string, method: string, body?: object) => Promise<any>;
+}) {
+    const { push } = useNotification();
+    const { revalidate } = useRevalidator();
     const [search, setSearch] = useState('');
     const [filter, setFilter] = useState<'all' | 'banned' | 'admins'>('all');
     const [loading, setLoading] = useState<string | null>(null);
 
     const [banTarget, setBanTarget] = useState<AdminUser | null>(null);
     const [banReason, setBanReason] = useState('');
+    const [banHours, setBanHours] = useState('');
     const [unbanTarget, setUnbanTarget] = useState<AdminUser | null>(null);
     const [promoteTarget, setPromoteTarget] = useState<AdminUser | null>(null);
+    const [demoteTarget, setDemoteTarget] = useState<AdminUser | null>(null);
 
-    const token = localStorage.getItem('token') ?? '';
-    const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
-
-    const filtered = initialUsers.filter(u => {
-        const matchSearch =
-            u.username.toLowerCase().includes(search.toLowerCase()) ||
+    const filtered = users.filter(u => {
+        const matchSearch = u.username.toLowerCase().includes(search.toLowerCase()) ||
             u.email.toLowerCase().includes(search.toLowerCase());
-        const matchFilter =
-            filter === 'all' ||
+        const matchFilter = filter === 'all' ||
             (filter === 'banned' && u.isBanned) ||
             (filter === 'admins' && u.role === 'ADMIN');
         return matchSearch && matchFilter;
     });
 
-    async function apiFetch(url: string, method: string, body?: object) {
-        const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
-        if (!res.ok) {
-            const err = await res.json().catch(() => ({}));
-            throw new Error(err.message ?? 'Request failed');
+    async function act(id: string, url: string, method: string, body?: object, successMsg?: string) {
+        setLoading(id);
+        try {
+            await apiFetch(url, method, body);
+            push({ type: 'success', title: 'Done', message: successMsg ?? 'Action completed.', duration: 4000 });
+            revalidate();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(null);
         }
-        return res.json();
     }
 
     async function confirmBan() {
         if (!banTarget) return;
-        setLoading(banTarget.id);
-        try {
-            await apiFetch(`/api/admin/users/${banTarget.id}/ban`, 'POST', { reason: banReason || undefined });
-            push({ type: 'success', title: 'User banned', message: `${banTarget.username} has been banned.`, duration: 4000 });
-            revalidate();
-        } catch (e: any) {
-            push({ type: 'error', title: 'Ban failed', message: e.message, duration: 5000 });
-        } finally {
-            setLoading(null);
-            setBanTarget(null);
-            setBanReason('');
-        }
-    }
-
-    async function confirmUnban() {
-        if (!unbanTarget) return;
-        setLoading(unbanTarget.id);
-        try {
-            await apiFetch(`/api/admin/users/${unbanTarget.id}/unban`, 'POST');
-            push({ type: 'success', title: 'User unbanned', message: `${unbanTarget.username} has been unbanned.`, duration: 4000 });
-            revalidate();
-        } catch (e: any) {
-            push({ type: 'error', title: 'Unban failed', message: e.message, duration: 5000 });
-        } finally {
-            setLoading(null);
-            setUnbanTarget(null);
-        }
-    }
-
-    async function confirmPromote() {
-        if (!promoteTarget) return;
-        setLoading(promoteTarget.id);
-        try {
-            await apiFetch(`/api/admin/users/${promoteTarget.id}/promote`, 'POST');
-            push({ type: 'success', title: 'User promoted', message: `${promoteTarget.username} is now an admin.`, duration: 4000 });
-            revalidate();
-        } catch (e: any) {
-            push({ type: 'error', title: 'Promote failed', message: e.message, duration: 5000 });
-        } finally {
-            setLoading(null);
-            setPromoteTarget(null);
-        }
+        const body: any = { reason: banReason || undefined };
+        if (banHours) body.durationHours = parseFloat(banHours);
+        await act(banTarget.id, `/api/admin/users/${banTarget.id}/ban`, 'POST', body,
+            `${banTarget.username} has been ${banHours ? `temp banned for ${banHours}h` : 'banned'}.`);
+        setBanTarget(null); setBanReason(''); setBanHours('');
     }
 
     return (
-        <div className="w-full max-w-5xl mx-auto py-8 px-4 flex flex-col gap-6">
-            {/* Header */}
-            <div className="flex items-center gap-3">
-                <Icons.ShieldAlert size={28} className="text-accent" />
-                <div>
-                    <h1 className="text-3xl font-heading font-bold text-text-default">Admin Panel</h1>
-                    <p className="text-sm text-text-default/50">Logged in as <span className="text-accent font-semibold">{me.username}</span></p>
-                </div>
-            </div>
-
-            {/* Stats bar */}
-            <div className="grid grid-cols-3 gap-4">
-                {[
-                    { label: 'Total users', value: initialUsers.length, icon: <Icons.Users size={18} /> },
-                    { label: 'Banned', value: initialUsers.filter(u => u.isBanned).length, icon: <Icons.Ban size={18} /> },
-                    { label: 'Admins', value: initialUsers.filter(u => u.role === 'ADMIN').length, icon: <Icons.ShieldCheck size={18} /> },
-                ].map(s => (
-                    <Card key={s.label} className="p-4 flex items-center gap-3">
-                        <span className="text-accent">{s.icon}</span>
-                        <div>
-                            <div className="text-xl font-bold text-text-default">{s.value}</div>
-                            <div className="text-xs text-text-default/50">{s.label}</div>
-                        </div>
-                    </Card>
-                ))}
-            </div>
-
-            {/* Search + filter */}
+        <div className="flex flex-col gap-4">
             <div className="flex flex-col sm:flex-row gap-3">
                 <div className="relative flex-1">
                     <Icons.Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-default/40" />
-                    <input
-                        type="text"
-                        placeholder="Search by username or email…"
-                        value={search}
+                    <input type="text" placeholder="Search username or email…" value={search}
                         onChange={e => setSearch(e.target.value)}
-                        className="w-full bg-primary border border-accent/20 rounded-lg pl-9 pr-4 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60"
-                    />
+                        className="w-full bg-primary border border-accent/20 rounded-lg pl-9 pr-4 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60" />
                 </div>
                 <div className="flex gap-2">
                     {(['all', 'banned', 'admins'] as const).map(f => (
-                        <button
-                            key={f}
-                            onClick={() => setFilter(f)}
-                            className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${
-                                filter === f
-                                    ? 'bg-accent text-text-dark'
-                                    : 'bg-primary text-text-default/60 hover:text-text-default'
-                            }`}
-                        >
+                        <button key={f} onClick={() => setFilter(f)}
+                            className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${filter === f ? 'bg-accent text-text-dark' : 'bg-primary text-text-default/60 hover:text-text-default'}`}>
                             {f}
                         </button>
                     ))}
                 </div>
             </div>
 
-            {/* User table */}
             <Card className="overflow-hidden">
                 <div className="overflow-x-auto">
                     <table className="w-full text-sm">
@@ -223,59 +174,50 @@ export default function AdminPanel() {
                         </thead>
                         <tbody className="divide-y divide-accent/10">
                             {filtered.length === 0 && (
-                                <tr>
-                                    <td colSpan={5} className="text-center py-10 text-text-default/30">No users found</td>
-                                </tr>
+                                <tr><td colSpan={5} className="text-center py-10 text-text-default/30">No users found</td></tr>
                             )}
                             {filtered.map(user => {
                                 const isSelf = user.id === me.id;
-                                const isbusy = loading === user.id;
+                                const busy = loading === user.id;
                                 return (
                                     <tr key={user.id} className={`transition-colors hover:bg-accent/5 ${user.isBanned ? 'opacity-60' : ''}`}>
                                         <td className="px-4 py-3">
                                             <div className="font-semibold text-text-default">{user.username}</div>
                                             {user.isBanned && user.banReason && (
-                                                <div className="text-xs text-red-400/70 mt-0.5 truncate max-w-[160px]" title={user.banReason}>
-                                                    {user.banReason}
-                                                </div>
+                                                <div className="text-xs text-red-400/70 mt-0.5 truncate max-w-[160px]">{user.banReason}</div>
+                                            )}
+                                            {user.isBanned && user.bannedUntil && (
+                                                <div className="text-xs text-orange-400/60 mt-0.5">Until {new Date(user.bannedUntil).toLocaleString()}</div>
                                             )}
                                         </td>
                                         <td className="px-4 py-3 text-text-default/60 hidden md:table-cell">{user.email}</td>
-                                        <td className="px-4 py-3"><StatusBadge user={user} /></td>
-                                        <td className="px-4 py-3 text-text-default/40 hidden lg:table-cell">
-                                            {new Date(user.createdAt).toLocaleDateString()}
-                                        </td>
+                                        <td className="px-4 py-3"><UserStatusBadge user={user} /></td>
+                                        <td className="px-4 py-3 text-text-default/40 hidden lg:table-cell">{new Date(user.createdAt).toLocaleDateString()}</td>
                                         <td className="px-4 py-3">
-                                            <div className="flex gap-2 justify-end">
+                                            <div className="flex gap-2 justify-end flex-wrap">
                                                 {isSelf ? (
                                                     <span className="text-xs text-text-default/30 pr-2">You</span>
                                                 ) : user.isBanned ? (
-                                                    <button
-                                                        disabled={isbusy}
-                                                        onClick={() => setUnbanTarget(user)}
-                                                        className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all disabled:opacity-40"
-                                                    >
+                                                    <button disabled={busy} onClick={() => setUnbanTarget(user)}
+                                                        className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all disabled:opacity-40">
                                                         <Icons.ShieldCheck size={13} /> Unban
                                                     </button>
                                                 ) : (
                                                     <>
-                                                        {user.role !== 'ADMIN' && (
-                                                            <>
-                                                                <button
-                                                                    disabled={isbusy}
-                                                                    onClick={() => setBanTarget(user)}
-                                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-tertiary hover:bg-tertiary-hover text-text-default transition-all disabled:opacity-40"
-                                                                >
-                                                                    <Icons.Ban size={13} /> Ban
-                                                                </button>
-                                                                <button
-                                                                    disabled={isbusy}
-                                                                    onClick={() => setPromoteTarget(user)}
-                                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-contrast hover:bg-contrast-hover text-text-default transition-all disabled:opacity-40"
-                                                                >
-                                                                    <Icons.ShieldPlus size={13} /> Promote
-                                                                </button>
-                                                            </>
+                                                        <button disabled={busy} onClick={() => setBanTarget(user)}
+                                                            className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-tertiary hover:bg-tertiary-hover text-text-default transition-all disabled:opacity-40">
+                                                            <Icons.Ban size={13} /> Ban
+                                                        </button>
+                                                        {user.role !== 'ADMIN' ? (
+                                                            <button disabled={busy} onClick={() => setPromoteTarget(user)}
+                                                                className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-contrast hover:bg-contrast-hover text-text-default transition-all disabled:opacity-40">
+                                                                <Icons.ShieldPlus size={13} /> Promote
+                                                            </button>
+                                                        ) : (
+                                                            <button disabled={busy} onClick={() => setDemoteTarget(user)}
+                                                                className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all disabled:opacity-40">
+                                                                <Icons.ShieldMinus size={13} /> Demote
+                                                            </button>
                                                         )}
                                                     </>
                                                 )}
@@ -289,49 +231,249 @@ export default function AdminPanel() {
                 </div>
             </Card>
 
-            {/* Ban dialog */}
             {banTarget && (
-                <ConfirmDialog
-                    title={`Ban ${banTarget.username}?`}
-                    message="This will immediately kick them from any active game and block login. Provide an optional reason:"
-                    confirmLabel="Ban user"
-                    confirmVariant="tertiary"
+                <ConfirmDialog title={`Ban ${banTarget.username}?`}
+                    message="Kicks them from active sessions immediately. Leave duration empty for permanent ban."
+                    confirmLabel="Ban" confirmVariant="tertiary"
                     onConfirm={confirmBan}
-                    onCancel={() => { setBanTarget(null); setBanReason(''); }}
-                >
-                    <input
-                        type="text"
-                        placeholder="Reason (optional)"
-                        value={banReason}
+                    onCancel={() => { setBanTarget(null); setBanReason(''); setBanHours(''); }}>
+                    <input type="text" placeholder="Reason (optional)" value={banReason}
                         onChange={e => setBanReason(e.target.value)}
-                        className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60"
-                    />
+                        className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60" />
+                    <div className="flex items-center gap-2">
+                        <input type="number" placeholder="Duration in hours (leave empty = permanent)" value={banHours}
+                            onChange={e => setBanHours(e.target.value)} min="1"
+                            className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60" />
+                    </div>
                 </ConfirmDialog>
             )}
-
-            {/* Unban dialog */}
             {unbanTarget && (
-                <ConfirmDialog
-                    title={`Unban ${unbanTarget.username}?`}
+                <ConfirmDialog title={`Unban ${unbanTarget.username}?`}
                     message="They will be able to log in and play again immediately."
-                    confirmLabel="Unban"
-                    confirmVariant="secondary"
-                    onConfirm={confirmUnban}
-                    onCancel={() => setUnbanTarget(null)}
-                />
+                    confirmLabel="Unban" confirmVariant="secondary"
+                    onConfirm={async () => { await act(unbanTarget.id, `/api/admin/users/${unbanTarget.id}/unban`, 'POST', undefined, `${unbanTarget.username} unbanned.`); setUnbanTarget(null); }}
+                    onCancel={() => setUnbanTarget(null)} />
             )}
-
-            {/* Promote dialog */}
             {promoteTarget && (
-                <ConfirmDialog
-                    title={`Promote ${promoteTarget.username} to Admin?`}
-                    message="They will gain full admin access. This cannot be undone from the UI."
-                    confirmLabel="Promote"
-                    confirmVariant="accent"
-                    onConfirm={confirmPromote}
-                    onCancel={() => setPromoteTarget(null)}
-                />
+                <ConfirmDialog title={`Promote ${promoteTarget.username} to Admin?`}
+                    message="They gain full admin access including the ability to ban and promote users."
+                    confirmLabel="Promote" confirmVariant="accent"
+                    onConfirm={async () => { await act(promoteTarget.id, `/api/admin/users/${promoteTarget.id}/promote`, 'POST', undefined, `${promoteTarget.username} is now admin.`); setPromoteTarget(null); }}
+                    onCancel={() => setPromoteTarget(null)} />
             )}
+            {demoteTarget && (
+                <ConfirmDialog title={`Demote ${demoteTarget.username}?`}
+                    message="They will lose all admin privileges immediately."
+                    confirmLabel="Demote" confirmVariant="tertiary"
+                    onConfirm={async () => { await act(demoteTarget.id, `/api/admin/users/${demoteTarget.id}/demote`, 'POST', undefined, `${demoteTarget.username} demoted.`); setDemoteTarget(null); }}
+                    onCancel={() => setDemoteTarget(null)} />
+            )}
+        </div>
+    );
+}
+
+function ReportsTab({ reports, apiFetch }: {
+    reports: Report[];
+    apiFetch: (url: string, method: string, body?: object) => Promise<any>;
+}) {
+    const { push } = useNotification();
+    const { revalidate } = useRevalidator();
+    const [filter, setFilter] = useState<'PENDING' | 'RESOLVED' | 'DISMISSED'>('PENDING');
+    const [loading, setLoading] = useState<string | null>(null);
+
+    const filtered = reports.filter(r => r.status === filter);
+
+    async function action(reportId: string, endpoint: string, label: string) {
+        setLoading(reportId);
+        try {
+            await apiFetch(`/api/admin/reports/${reportId}/${endpoint}`, 'POST');
+            push({ type: 'success', title: label, message: 'Report updated.', duration: 3000 });
+            revalidate();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(null);
+        }
+    }
+
+    const pending = reports.filter(r => r.status === 'PENDING').length;
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex gap-2">
+                {(['PENDING', 'RESOLVED', 'DISMISSED'] as const).map(f => (
+                    <button key={f} onClick={() => setFilter(f)}
+                        className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${filter === f ? 'bg-accent text-text-dark' : 'bg-primary text-text-default/60 hover:text-text-default'}`}>
+                        {f.toLowerCase()} {f === 'PENDING' && pending > 0 && <span className="ml-1 bg-red-500 text-white rounded-full px-1.5 text-xs">{pending}</span>}
+                    </button>
+                ))}
+            </div>
+
+            <Card className="overflow-hidden">
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b border-accent/10 text-text-default/40 text-xs uppercase tracking-wider">
+                                <th className="text-left px-4 py-3">Reporter</th>
+                                <th className="text-left px-4 py-3">Reported</th>
+                                <th className="text-left px-4 py-3">Reason</th>
+                                <th className="text-left px-4 py-3 hidden md:table-cell">Date</th>
+                                {filter === 'PENDING' && <th className="text-right px-4 py-3">Actions</th>}
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-accent/10">
+                            {filtered.length === 0 && (
+                                <tr><td colSpan={5} className="text-center py-10 text-text-default/30">No reports</td></tr>
+                            )}
+                            {filtered.map(report => (
+                                <tr key={report.id} className="hover:bg-accent/5 transition-colors">
+                                    <td className="px-4 py-3 text-text-default/80">{report.reporter.username}</td>
+                                    <td className="px-4 py-3">
+                                        <span className="font-semibold text-text-default">{report.reported.username}</span>
+                                        {report.reported.isBanned && <span className="ml-1 text-xs text-red-400">(banned)</span>}
+                                    </td>
+                                    <td className="px-4 py-3 text-text-default/70 max-w-xs truncate">{report.reason}</td>
+                                    <td className="px-4 py-3 text-text-default/40 hidden md:table-cell">{new Date(report.createdAt).toLocaleDateString()}</td>
+                                    {filter === 'PENDING' && (
+                                        <td className="px-4 py-3">
+                                            <div className="flex gap-2 justify-end">
+                                                <button disabled={loading === report.id}
+                                                    onClick={() => action(report.id, 'resolve', 'Resolved')}
+                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all disabled:opacity-40">
+                                                    <Icons.Check size={13} /> Resolve
+                                                </button>
+                                                <button disabled={loading === report.id}
+                                                    onClick={() => action(report.id, 'dismiss', 'Dismissed')}
+                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-primary hover:bg-primary-hover text-text-default/60 transition-all disabled:opacity-40">
+                                                    <Icons.X size={13} /> Dismiss
+                                                </button>
+                                            </div>
+                                        </td>
+                                    )}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </Card>
+        </div>
+    );
+}
+
+function AuditTab({ auditLogs }: { auditLogs: AuditLog[] }) {
+    return (
+        <Card className="overflow-hidden">
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b border-accent/10 text-text-default/40 text-xs uppercase tracking-wider">
+                            <th className="text-left px-4 py-3">Admin</th>
+                            <th className="text-left px-4 py-3">Action</th>
+                            <th className="text-left px-4 py-3">Target</th>
+                            <th className="text-left px-4 py-3 hidden md:table-cell">Detail</th>
+                            <th className="text-left px-4 py-3">When</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-accent/10">
+                        {auditLogs.length === 0 && (
+                            <tr><td colSpan={5} className="text-center py-10 text-text-default/30">No audit logs yet</td></tr>
+                        )}
+                        {auditLogs.map(log => {
+                            const meta = ACTION_LABELS[log.action] ?? { label: log.action, color: 'text-text-default' };
+                            return (
+                                <tr key={log.id} className="hover:bg-accent/5 transition-colors">
+                                    <td className="px-4 py-3 font-semibold text-text-default">{log.adminName}</td>
+                                    <td className={`px-4 py-3 font-semibold ${meta.color}`}>{meta.label}</td>
+                                    <td className="px-4 py-3 text-text-default/70">{log.targetName ?? '—'}</td>
+                                    <td className="px-4 py-3 text-text-default/50 hidden md:table-cell truncate max-w-xs">{log.detail ?? '—'}</td>
+                                    <td className="px-4 py-3 text-text-default/40 whitespace-nowrap">{new Date(log.createdAt).toLocaleString()}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </Card>
+    );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function AdminPanel() {
+    const { me, users, reports, auditLogs } = useLoaderData() as LoaderData;
+    const [tab, setTab] = useState<'users' | 'reports' | 'audit'>('users');
+
+    const token = localStorage.getItem('token') ?? '';
+    const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+    async function apiFetch(url: string, method: string, body?: object) {
+        const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.message ?? 'Request failed');
+        }
+        return res.json();
+    }
+
+    const pendingReports = reports.filter(r => r.status === 'PENDING').length;
+
+    const tabs = [
+        { id: 'users' as const, label: 'Users', icon: <Icons.Users size={16} />, badge: null },
+        { id: 'reports' as const, label: 'Reports', icon: <Icons.Flag size={16} />, badge: pendingReports > 0 ? pendingReports : null },
+        { id: 'audit' as const, label: 'Audit Log', icon: <Icons.ScrollText size={16} />, badge: null },
+    ];
+
+    return (
+        <div className="w-full max-w-5xl mx-auto py-8 px-4 flex flex-col gap-6">
+            {/* Header */}
+            <div className="flex items-center gap-3">
+                <Icons.ShieldAlert size={28} className="text-accent" />
+                <div>
+                    <h1 className="text-3xl font-heading font-bold text-text-default">Admin Panel</h1>
+                    <p className="text-sm text-text-default/50">Logged in as <span className="text-accent font-semibold">{me.username}</span></p>
+                </div>
+            </div>
+
+            {/* Stats */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                {[
+                    { label: 'Total users', value: users.length, icon: <Icons.Users size={18} /> },
+                    { label: 'Banned', value: users.filter(u => u.isBanned).length, icon: <Icons.Ban size={18} /> },
+                    { label: 'Admins', value: users.filter(u => u.role === 'ADMIN').length, icon: <Icons.ShieldCheck size={18} /> },
+                    { label: 'Pending reports', value: pendingReports, icon: <Icons.Flag size={18} />, alert: pendingReports > 0 },
+                ].map(s => (
+                    <Card key={s.label} className={`p-4 flex items-center gap-3 ${(s as any).alert ? 'border border-red-500/40' : ''}`}>
+                        <span className={`${ (s as any).alert ? 'text-red-400' : 'text-accent'}`}>{s.icon}</span>
+                        <div>
+                            <div className={`text-xl font-bold ${(s as any).alert ? 'text-red-400' : 'text-text-default'}`}>{s.value}</div>
+                            <div className="text-xs text-text-default/50">{s.label}</div>
+                        </div>
+                    </Card>
+                ))}
+            </div>
+
+            {/* Tab bar */}
+            <div className="flex gap-1 border-b border-accent/10 pb-0">
+                {tabs.map(t => (
+                    <button key={t.id} onClick={() => setTab(t.id)}
+                        className={`flex items-center gap-2 px-4 py-2.5 text-sm font-semibold transition-all border-b-2 -mb-px ${
+                            tab === t.id
+                                ? 'border-accent text-accent'
+                                : 'border-transparent text-text-default/50 hover:text-text-default'
+                        }`}>
+                        {t.icon}
+                        {t.label}
+                        {t.badge !== null && (
+                            <span className="bg-red-500 text-white rounded-full px-1.5 text-xs leading-5">{t.badge}</span>
+                        )}
+                    </button>
+                ))}
+            </div>
+
+            {/* Tab content */}
+            {tab === 'users' && <UsersTab users={users} me={me} apiFetch={apiFetch} />}
+            {tab === 'reports' && <ReportsTab reports={reports} apiFetch={apiFetch} />}
+            {tab === 'audit' && <AuditTab auditLogs={auditLogs} />}
         </div>
     );
 }

--- a/frontend/src/pages/Admin/AdminPanel.tsx
+++ b/frontend/src/pages/Admin/AdminPanel.tsx
@@ -1,0 +1,337 @@
+import React, { useState } from 'react';
+import { useLoaderData, useRevalidator } from 'react-router-dom';
+import * as Icons from 'lucide-react';
+import { Card } from '../../components/ui/Card';
+import Button from '../../components/Button';
+import { useNotification } from '../../notifications';
+
+interface AdminUser {
+    id: string;
+    username: string;
+    email: string;
+    role: 'USER' | 'ADMIN';
+    isBanned: boolean;
+    bannedAt: string | null;
+    banReason: string | null;
+    createdAt: string;
+    isOnline: boolean;
+}
+
+interface LoaderData {
+    me: { id: string; username: string; role: string };
+    users: AdminUser[];
+}
+
+function ConfirmDialog({
+    title,
+    message,
+    confirmLabel,
+    confirmVariant = 'tertiary',
+    onConfirm,
+    onCancel,
+    children,
+}: {
+    title: string;
+    message: string;
+    confirmLabel: string;
+    confirmVariant?: 'primary' | 'secondary' | 'accent' | 'tertiary';
+    onConfirm: () => void;
+    onCancel: () => void;
+    children?: React.ReactNode;
+}) {
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <Card className="w-full max-w-md p-6 flex flex-col gap-4 mx-4">
+                <h2 className="text-xl font-heading font-bold text-text-default">{title}</h2>
+                <p className="text-sm text-text-default/80">{message}</p>
+                {children}
+                <div className="flex gap-3 justify-end mt-2">
+                    <Button variant="secondary" onClick={onCancel} className="px-4 py-2 text-sm">
+                        Cancel
+                    </Button>
+                    <Button variant={confirmVariant} onClick={onConfirm} className="px-4 py-2 text-sm">
+                        {confirmLabel}
+                    </Button>
+                </div>
+            </Card>
+        </div>
+    );
+}
+
+function StatusBadge({ user }: { user: AdminUser }) {
+    if (user.isBanned)
+        return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-red-900/60 text-red-300"><Icons.Ban size={11} /> Banned</span>;
+    if (user.role === 'ADMIN')
+        return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-accent/20 text-accent"><Icons.ShieldCheck size={11} /> Admin</span>;
+    if (user.isOnline)
+        return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-900/60 text-green-300"><Icons.Circle size={11} fill="currentColor" /> Online</span>;
+    return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-primary/40 text-text-default/50"><Icons.Circle size={11} /> Offline</span>;
+}
+
+export default function AdminPanel() {
+    const { me, users: initialUsers } = useLoaderData() as LoaderData;
+    const { revalidate } = useRevalidator();
+    const { push } = useNotification();
+
+    const [search, setSearch] = useState('');
+    const [filter, setFilter] = useState<'all' | 'banned' | 'admins'>('all');
+    const [loading, setLoading] = useState<string | null>(null);
+
+    const [banTarget, setBanTarget] = useState<AdminUser | null>(null);
+    const [banReason, setBanReason] = useState('');
+    const [unbanTarget, setUnbanTarget] = useState<AdminUser | null>(null);
+    const [promoteTarget, setPromoteTarget] = useState<AdminUser | null>(null);
+
+    const token = localStorage.getItem('token') ?? '';
+    const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+    const filtered = initialUsers.filter(u => {
+        const matchSearch =
+            u.username.toLowerCase().includes(search.toLowerCase()) ||
+            u.email.toLowerCase().includes(search.toLowerCase());
+        const matchFilter =
+            filter === 'all' ||
+            (filter === 'banned' && u.isBanned) ||
+            (filter === 'admins' && u.role === 'ADMIN');
+        return matchSearch && matchFilter;
+    });
+
+    async function apiFetch(url: string, method: string, body?: object) {
+        const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.message ?? 'Request failed');
+        }
+        return res.json();
+    }
+
+    async function confirmBan() {
+        if (!banTarget) return;
+        setLoading(banTarget.id);
+        try {
+            await apiFetch(`/api/admin/users/${banTarget.id}/ban`, 'POST', { reason: banReason || undefined });
+            push({ type: 'success', title: 'User banned', message: `${banTarget.username} has been banned.`, duration: 4000 });
+            revalidate();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Ban failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(null);
+            setBanTarget(null);
+            setBanReason('');
+        }
+    }
+
+    async function confirmUnban() {
+        if (!unbanTarget) return;
+        setLoading(unbanTarget.id);
+        try {
+            await apiFetch(`/api/admin/users/${unbanTarget.id}/unban`, 'POST');
+            push({ type: 'success', title: 'User unbanned', message: `${unbanTarget.username} has been unbanned.`, duration: 4000 });
+            revalidate();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Unban failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(null);
+            setUnbanTarget(null);
+        }
+    }
+
+    async function confirmPromote() {
+        if (!promoteTarget) return;
+        setLoading(promoteTarget.id);
+        try {
+            await apiFetch(`/api/admin/users/${promoteTarget.id}/promote`, 'POST');
+            push({ type: 'success', title: 'User promoted', message: `${promoteTarget.username} is now an admin.`, duration: 4000 });
+            revalidate();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Promote failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(null);
+            setPromoteTarget(null);
+        }
+    }
+
+    return (
+        <div className="w-full max-w-5xl mx-auto py-8 px-4 flex flex-col gap-6">
+            {/* Header */}
+            <div className="flex items-center gap-3">
+                <Icons.ShieldAlert size={28} className="text-accent" />
+                <div>
+                    <h1 className="text-3xl font-heading font-bold text-text-default">Admin Panel</h1>
+                    <p className="text-sm text-text-default/50">Logged in as <span className="text-accent font-semibold">{me.username}</span></p>
+                </div>
+            </div>
+
+            {/* Stats bar */}
+            <div className="grid grid-cols-3 gap-4">
+                {[
+                    { label: 'Total users', value: initialUsers.length, icon: <Icons.Users size={18} /> },
+                    { label: 'Banned', value: initialUsers.filter(u => u.isBanned).length, icon: <Icons.Ban size={18} /> },
+                    { label: 'Admins', value: initialUsers.filter(u => u.role === 'ADMIN').length, icon: <Icons.ShieldCheck size={18} /> },
+                ].map(s => (
+                    <Card key={s.label} className="p-4 flex items-center gap-3">
+                        <span className="text-accent">{s.icon}</span>
+                        <div>
+                            <div className="text-xl font-bold text-text-default">{s.value}</div>
+                            <div className="text-xs text-text-default/50">{s.label}</div>
+                        </div>
+                    </Card>
+                ))}
+            </div>
+
+            {/* Search + filter */}
+            <div className="flex flex-col sm:flex-row gap-3">
+                <div className="relative flex-1">
+                    <Icons.Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-default/40" />
+                    <input
+                        type="text"
+                        placeholder="Search by username or email…"
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        className="w-full bg-primary border border-accent/20 rounded-lg pl-9 pr-4 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60"
+                    />
+                </div>
+                <div className="flex gap-2">
+                    {(['all', 'banned', 'admins'] as const).map(f => (
+                        <button
+                            key={f}
+                            onClick={() => setFilter(f)}
+                            className={`px-4 py-2 rounded-lg text-sm font-semibold capitalize transition-all ${
+                                filter === f
+                                    ? 'bg-accent text-text-dark'
+                                    : 'bg-primary text-text-default/60 hover:text-text-default'
+                            }`}
+                        >
+                            {f}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* User table */}
+            <Card className="overflow-hidden">
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="border-b border-accent/10 text-text-default/40 text-xs uppercase tracking-wider">
+                                <th className="text-left px-4 py-3">User</th>
+                                <th className="text-left px-4 py-3 hidden md:table-cell">Email</th>
+                                <th className="text-left px-4 py-3">Status</th>
+                                <th className="text-left px-4 py-3 hidden lg:table-cell">Joined</th>
+                                <th className="text-right px-4 py-3">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-accent/10">
+                            {filtered.length === 0 && (
+                                <tr>
+                                    <td colSpan={5} className="text-center py-10 text-text-default/30">No users found</td>
+                                </tr>
+                            )}
+                            {filtered.map(user => {
+                                const isSelf = user.id === me.id;
+                                const isbusy = loading === user.id;
+                                return (
+                                    <tr key={user.id} className={`transition-colors hover:bg-accent/5 ${user.isBanned ? 'opacity-60' : ''}`}>
+                                        <td className="px-4 py-3">
+                                            <div className="font-semibold text-text-default">{user.username}</div>
+                                            {user.isBanned && user.banReason && (
+                                                <div className="text-xs text-red-400/70 mt-0.5 truncate max-w-[160px]" title={user.banReason}>
+                                                    {user.banReason}
+                                                </div>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3 text-text-default/60 hidden md:table-cell">{user.email}</td>
+                                        <td className="px-4 py-3"><StatusBadge user={user} /></td>
+                                        <td className="px-4 py-3 text-text-default/40 hidden lg:table-cell">
+                                            {new Date(user.createdAt).toLocaleDateString()}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <div className="flex gap-2 justify-end">
+                                                {isSelf ? (
+                                                    <span className="text-xs text-text-default/30 pr-2">You</span>
+                                                ) : user.isBanned ? (
+                                                    <button
+                                                        disabled={isbusy}
+                                                        onClick={() => setUnbanTarget(user)}
+                                                        className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-secondary hover:bg-secondary-hover text-text-default transition-all disabled:opacity-40"
+                                                    >
+                                                        <Icons.ShieldCheck size={13} /> Unban
+                                                    </button>
+                                                ) : (
+                                                    <>
+                                                        {user.role !== 'ADMIN' && (
+                                                            <>
+                                                                <button
+                                                                    disabled={isbusy}
+                                                                    onClick={() => setBanTarget(user)}
+                                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-tertiary hover:bg-tertiary-hover text-text-default transition-all disabled:opacity-40"
+                                                                >
+                                                                    <Icons.Ban size={13} /> Ban
+                                                                </button>
+                                                                <button
+                                                                    disabled={isbusy}
+                                                                    onClick={() => setPromoteTarget(user)}
+                                                                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold bg-contrast hover:bg-contrast-hover text-text-default transition-all disabled:opacity-40"
+                                                                >
+                                                                    <Icons.ShieldPlus size={13} /> Promote
+                                                                </button>
+                                                            </>
+                                                        )}
+                                                    </>
+                                                )}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            </Card>
+
+            {/* Ban dialog */}
+            {banTarget && (
+                <ConfirmDialog
+                    title={`Ban ${banTarget.username}?`}
+                    message="This will immediately kick them from any active game and block login. Provide an optional reason:"
+                    confirmLabel="Ban user"
+                    confirmVariant="tertiary"
+                    onConfirm={confirmBan}
+                    onCancel={() => { setBanTarget(null); setBanReason(''); }}
+                >
+                    <input
+                        type="text"
+                        placeholder="Reason (optional)"
+                        value={banReason}
+                        onChange={e => setBanReason(e.target.value)}
+                        className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60"
+                    />
+                </ConfirmDialog>
+            )}
+
+            {/* Unban dialog */}
+            {unbanTarget && (
+                <ConfirmDialog
+                    title={`Unban ${unbanTarget.username}?`}
+                    message="They will be able to log in and play again immediately."
+                    confirmLabel="Unban"
+                    confirmVariant="secondary"
+                    onConfirm={confirmUnban}
+                    onCancel={() => setUnbanTarget(null)}
+                />
+            )}
+
+            {/* Promote dialog */}
+            {promoteTarget && (
+                <ConfirmDialog
+                    title={`Promote ${promoteTarget.username} to Admin?`}
+                    message="They will gain full admin access. This cannot be undone from the UI."
+                    confirmLabel="Promote"
+                    confirmVariant="accent"
+                    onConfirm={confirmPromote}
+                    onCancel={() => setPromoteTarget(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/Game/GamePage.tsx
+++ b/frontend/src/pages/Game/GamePage.tsx
@@ -37,6 +37,7 @@ const GamePage: React.FC = () => {
 	const [waiting, setWaiting] = useState(true);
 
 	const [players, setPlayers] = useState<{ white: string, black: string } | null>(null);
+	const [playerUserIds, setPlayerUserIds] = useState<{ white: string | null, black: string | null } | null>(null);
 
 	const hasConnected = useRef(false);
 
@@ -100,6 +101,7 @@ const GamePage: React.FC = () => {
 				black: { userId: string | null; username: string };
 			}) => {
 				setPlayers({ white: data.white.username, black: data.black.username });
+				setPlayerUserIds({ white: data.white.userId, black: data.black.userId });
 			});
 
 			socketService.joinGame(gameId, tcKey, state.role ?? undefined);
@@ -174,6 +176,10 @@ const GamePage: React.FC = () => {
 		);
 	}
 
+	const opponentColor = role === 'white' ? 'black' : 'white';
+	const opponentUserId = playerUserIds?.[opponentColor] ?? null;
+	const opponentUsername = players?.[opponentColor] ?? null;
+
 	return (
 		<ChessGame
 			gameId={gameId}
@@ -185,6 +191,8 @@ const GamePage: React.FC = () => {
 			incrementMs={timeControl.incrementMs}
 			initialGameOver={initialGameOver}
 			players={players}
+			opponentUserId={opponentUserId}
+			opponentUsername={opponentUsername}
 		/>
 	);
 };

--- a/frontend/src/pages/User/FriendProfilePage.tsx
+++ b/frontend/src/pages/User/FriendProfilePage.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams, useNavigate, useLocation, useLoaderData } from 'react-router-dom';
 import FriendProfileTile from '../../components/FriendProfileTile';
 import Button from '../../components/Button';
 import * as Icons from 'lucide-react';
 import { GameModeStatsCard } from '../../components/GameModeStatsCard';
 import GameHistoryList, { GameHistoryItem } from '../../components/GameHistoryList';
+import { useNotification } from '../../notifications';
 
 interface ChartDataPoint {
     date: string;
@@ -53,10 +54,68 @@ const StatsView = ({ chartData }: { chartData: ChartData }) => {
     );
 };
 
+function ReportModal({ userId, username, onClose }: { userId: string; username: string; onClose: () => void }) {
+    const [reason, setReason] = useState('');
+    const [loading, setLoading] = useState(false);
+    const { push } = useNotification();
+
+    async function submit() {
+        if (!reason.trim()) return;
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/users/${userId}/report`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+                body: JSON.stringify({ reason: reason.trim() }),
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.message ?? 'Failed');
+            }
+            push({ type: 'success', title: 'Report submitted', message: 'Admins will review your report.', duration: 4000 });
+            onClose();
+        } catch (e: any) {
+            push({ type: 'error', title: 'Report failed', message: e.message, duration: 5000 });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <div className="bg-primary rounded-xl shadow-xl p-6 w-full max-w-md mx-4 flex flex-col gap-4">
+                <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-heading font-bold text-text-default flex items-center gap-2">
+                        <Icons.Flag size={20} className="text-accent" /> Report {username}
+                    </h2>
+                    <button onClick={onClose} className="text-text-default/40 hover:text-text-default transition-colors">
+                        <Icons.X size={20} />
+                    </button>
+                </div>
+                <p className="text-sm text-text-default/60">Describe why you're reporting this player. Admins will review your report.</p>
+                <textarea
+                    value={reason}
+                    onChange={e => setReason(e.target.value)}
+                    placeholder="e.g. Using a chess engine, abusive behavior…"
+                    rows={4}
+                    className="w-full bg-contrast border border-accent/20 rounded-lg px-3 py-2 text-sm text-text-default placeholder:text-text-default/30 focus:outline-none focus:border-accent/60 resize-none"
+                />
+                <div className="flex gap-3 justify-end">
+                    <Button variant="secondary" onClick={onClose} className="px-4 py-2 text-sm">Cancel</Button>
+                    <Button variant="tertiary" onClick={submit} disabled={!reason.trim() || loading} className="px-4 py-2 text-sm">
+                        {loading ? 'Sending…' : 'Submit report'}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function FriendProfilePage() {
     const { username } = useParams<{ username: string }>();
     const navigate = useNavigate();
     const location = useLocation();
+    const [reportOpen, setReportOpen] = useState(false);
     
     const profile = location.state?.friendData;
     const { friendData } = useLoaderData() as { friendData: any };
@@ -110,12 +169,23 @@ export default function FriendProfilePage() {
                 <GameHistoryList history={historyData} />
             </div>
 
-            {/* Back Button positioned below the tile */}
-            <div className="flex justify-center md:justify-start mt-2">
-                 <Button variant="tertiary" onClick={() => navigate(-1)} className="text-sm px-6 py-2">
-                     &larr; Back
-                 </Button>
+            {/* Back + Report */}
+            <div className="flex justify-between items-center mt-2">
+                <Button variant="tertiary" onClick={() => navigate(-1)} className="text-sm px-6 py-2">
+                    &larr; Back
+                </Button>
+                <Button variant="secondary" onClick={() => setReportOpen(true)} className="text-sm px-4 py-2 flex items-center gap-2">
+                    <Icons.Flag size={15} /> Report
+                </Button>
             </div>
+
+            {reportOpen && (
+                <ReportModal
+                    userId={friendData?.id}
+                    username={friendData?.username || profile?.username}
+                    onClose={() => setReportOpen(false)}
+                />
+            )}
         </div>
     );
 }

--- a/frontend/src/services/loaders.service.ts
+++ b/frontend/src/services/loaders.service.ts
@@ -73,19 +73,22 @@ export async function friendLoader({ params }: any) {
 }
 
 export async function adminLoader() {
-  const [meRes, usersRes] = await Promise.all([
+  const [meRes, usersRes, reportsRes, auditRes] = await Promise.all([
     fetch('/api/users/me', { headers: getApiHeaders() }),
     fetch('/api/admin/users', { headers: getApiHeaders() }),
+    fetch('/api/admin/reports', { headers: getApiHeaders() }),
+    fetch('/api/admin/audit-logs', { headers: getApiHeaders() }),
   ]);
 
-  if (meRes.status === 401) throw new Error('Unauthorized');
-  if (usersRes.status === 401) throw new Error('Unauthorized');
+  if (meRes.status === 401 || usersRes.status === 401) throw new Error('Unauthorized');
   if (usersRes.status === 403) throw new Error('Forbidden');
-  if (!meRes.ok || !usersRes.ok) throw new Error('Failed');
+  if (!meRes.ok || !usersRes.ok || !reportsRes.ok || !auditRes.ok) throw new Error('Failed');
 
-  const [me, users] = await Promise.all([meRes.json(), usersRes.json()]);
+  const [me, users, reports, auditLogs] = await Promise.all([
+    meRes.json(), usersRes.json(), reportsRes.json(), auditRes.json(),
+  ]);
 
   if (me.role !== 'ADMIN') throw new Error('Forbidden');
 
-  return { me, users };
+  return { me, users, reports, auditLogs };
 }

--- a/frontend/src/services/loaders.service.ts
+++ b/frontend/src/services/loaders.service.ts
@@ -71,3 +71,21 @@ export async function friendLoader({ params }: any) {
   const friendData = await friendRes.json()
   return { friendData };
 }
+
+export async function adminLoader() {
+  const [meRes, usersRes] = await Promise.all([
+    fetch('/api/users/me', { headers: getApiHeaders() }),
+    fetch('/api/admin/users', { headers: getApiHeaders() }),
+  ]);
+
+  if (meRes.status === 401) throw new Error('Unauthorized');
+  if (usersRes.status === 401) throw new Error('Unauthorized');
+  if (usersRes.status === 403) throw new Error('Forbidden');
+  if (!meRes.ok || !usersRes.ok) throw new Error('Failed');
+
+  const [me, users] = await Promise.all([meRes.json(), usersRes.json()]);
+
+  if (me.role !== 'ADMIN') throw new Error('Forbidden');
+
+  return { me, users };
+}


### PR DESCRIPTION
admin system, bans, reports, audit log, username filter

  ## Admin accounts
  - Add UserRole enum (USER/ADMIN) to User schema
  - ADMIN_EMAIL env var auto-promotes user on backend startup
  - AdminGuard: JWT verify + DB role check on every admin request
  - POST /admin/users/:id/promote — grant admin
  - POST /admin/users/:id/demote — revoke admin (cannot self-demote)

  ## Ban system
  - Add isBanned, bannedAt, bannedUntil, banReason fields to User
  - Permanent and temporary bans (durationHours in request body)
  - Ban enforced at 3 layers: login, every HTTP request (AuthGuard), WS connect
  - Expired temp bans auto-lifted on next login or request
  - POST /admin/users/:id/ban — ban with optional reason + duration
  - POST /admin/users/:id/unban
  - Active WebSocket connections kicked instantly on ban (GameGateway.kickUser)

  ## Audit log
  - AuditLog model: records admin, target, action, detail, timestamp
  - Every admin action (ban, unban, promote, demote, report resolve/dismiss) logged
  - GET /admin/audit-logs — last 500 entries

  ## Player report system
  - Report model with PENDING/RESOLVED/DISMISSED status
  - POST /users/:id/report — any authenticated user can report
  - Duplicate pending report guard (one open report per pair)
  - Cannot report yourself
  - GET /admin/reports — full list with reporter/reported info
  - POST /admin/reports/:id/resolve|dismiss
  - Report triggers logged in audit log

  ## Admin panel (frontend)
  - /admin route behind AdminRoute guard (role check before render)
  - 3-tab UI: Users | Reports | Audit Log
  - Users tab: ban (with reason + duration), unban, promote, demote
    — cannot ban admins, cannot demote self
    — confirmation dialogs on all destructive actions
  - Reports tab: pending count badge, resolve/dismiss per report
  - Audit log tab: color-coded actions, chronological
  - Stats bar: total users, banned count, admin count, pending reports
  - Admin link in navbar visible only to ADMIN role users

  ## Report UX (frontend)
  - Game end popup: "Report opponent" link expands inline after match
  - Game history list: flag icon next to each past opponent's name
  - Friend profile page: Report button opens reason modal
  - opponentId threaded from game:players socket event through GamePage
    → ChessGame → GameEndPopup

  ## Username filter
  - Blocklist of profanity, slurs, hate-group names, common leet bypasses
  - Normalizes input (strips . _ - separators) before matching
  - Enforced at registration and username change (400 if blocked)